### PR TITLE
Support passing fallback user info for providers like Discord

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
   "editor.codeActionsOnSave": {
-    "source.fixAll": true
-  },
+    "source.fixAll": "explicit"
+  }
 }

--- a/src/Web3Auth.ts
+++ b/src/Web3Auth.ts
@@ -303,11 +303,16 @@ class Web3Auth extends SafeEventEmitter implements IWeb3Auth {
     const sessionId = OpenloginSessionManager.generateRandomSessionKey();
     this.sessionManager.sessionId = sessionId;
     // we are using the original private key so that we can retrieve other keys later on
-    const decodedToken = jwtDecode<Auth0UserInfo>(idToken);
+    let decodedUserInfo: Partial<Auth0UserInfo>;
+    try {
+      decodedUserInfo = jwtDecode<Auth0UserInfo>(idToken);
+    } catch (error) {
+      decodedUserInfo = loginParams.fallbackUserInfo;
+    }
     const userInfo: OpenloginUserInfo = {
-      name: decodedToken.name || decodedToken.nickname || "",
-      email: decodedToken.email || "",
-      profileImage: decodedToken.picture || "",
+      name: decodedUserInfo.name || decodedUserInfo.nickname || "",
+      email: decodedUserInfo.email || "",
+      profileImage: decodedUserInfo.picture || "",
       verifierId,
       verifier,
       typeOfLogin: "jwt",

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -13,15 +13,6 @@ export type InitParams = { network: TORUS_NETWORK_TYPE };
 
 export type PrivateKeyProvider = IBaseProvider<string> & { getEd25519Key?: (privKey: string) => string };
 
-export type LoginParams = {
-  verifier: string;
-  verifierId: string;
-  idToken: string;
-  subVerifierInfoArray?: TorusSubVerifierInfo[];
-  // offset in seconds
-  serverTimeOffset?: number;
-};
-
 export type UserAuthInfo = { idToken: string };
 
 export interface Web3AuthOptions {
@@ -90,6 +81,16 @@ export interface SessionData {
   privKey?: string;
   userInfo?: OpenloginUserInfo;
 }
+
+export type LoginParams = {
+  verifier: string;
+  verifierId: string;
+  idToken: string;
+  subVerifierInfoArray?: TorusSubVerifierInfo[];
+  // offset in seconds
+  serverTimeOffset?: number;
+  fallbackUserInfo?: Partial<Auth0UserInfo>;
+};
 
 export type ADAPTER_STATUS_TYPE = (typeof ADAPTER_STATUS)[keyof typeof ADAPTER_STATUS];
 


### PR DESCRIPTION
motivation: idToken (accessToken) for Discord fails `jwtDecode` because it has too little information, so it needs to be passed from outside where it can be obtained e.g. from the discord oauth response (but not the `accessToken` itself)